### PR TITLE
Added script to initialize ACR and related service principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The artifacts used to deploy this project include bash scripts and Terraform tem
     $ ./acr-sp-init.sh -c Cobalt -l eastus
     ```
 
+    > Note: The script configures service principals in Azure AD and therefore requires elevated privileges.  As such, it is recommended that an interactive user with permissions to configure Azure AD run the script.
+    
+    
 ## Setup Shared / Core Infrastructure
 
 > Coming soon!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
 
+# Setup
+
+The artifacts used to deploy this project include bash scripts and Terraform templates.  The sections below provide guidance to deploy this project into your Azure environment.
+
+> The setup instructions below assume the following requirements:
+> - bash v4.0 (or newer)
+> - Terraform v0.11.13 (or newer)
+
+
+## Setup the Azure Container Registry and Service Principals
+
+1. Open a bash command prompt.
+2. Navigate to the `./setup` folder.
+3. Run `acr-sp-init.sh`.  For example, the command below will provdision an Azure Container Registry (ACR) in East US and configure the two service principals in Azure Active Directory; one with AcrPush permission and another with AcrPull permission scoped to the ACR.  The company name parameter ( `-c` ) is used to construct the name of the resource group, ACR, and service principals.
+
+    ``` bash
+    $ ./acr-sp-init.sh -c Cobalt -l eastus
+    ```
+
+## Setup Shared / Core Infrastructure
+
+> Coming soon!
+
+## Setup Application Infrastructure
+
+> Coming soon!
+
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The artifacts used to deploy this project include bash scripts and Terraform tem
 
 > The setup instructions below assume the following requirements:
 > - bash v4.0 (or newer)
+>   - **NOTE FOR MAC!** The default version of bash installed on Mac is older than 4.0. Be sure to update bash using brew before executing the script. Instructions to update bash can be found [here](http://macappstore.org/bash/).
 > - Terraform v0.11.13 (or newer)
 
 

--- a/setup/acr-sp-init.sh
+++ b/setup/acr-sp-init.sh
@@ -1,0 +1,124 @@
+#!/bin/bash -e
+
+while getopts "c:l:" opt; do
+    case $opt in
+        c)
+            # Company name 
+            company=$OPTARG
+        ;;
+        l)
+            # Location/region where resource group will deploy to
+            location=$OPTARG 
+        ;;
+    esac
+done
+
+# If user did not provide required parameters then show usage.
+[[ $# -eq 0 || -z $company || -z $location ]] && 
+{ 
+    echo "Usage:";
+    echo "  $0 -c <company name> -l <location/region>";
+    echo "  Use \"az account list-locations --query '[].name'\" to list supported regions for a subscription.'"
+    echo "";
+    echo "Example:";
+    echo "  $0 -c contoso -l eastus";
+    exit 1; 
+}
+
+# Convert to lowercase, remove whitespace, and trim lenght if needed.
+location=${location// /}
+location=${location,,}
+
+company=${company// /}
+company=${company,,}
+company=${company:0:8}
+
+# Translate location to an abbreviated location code.
+locationCode=""
+declare -A locationCodes=(
+    # Asia
+    ["eastasia"]="asea"
+    ["southeastasia"]="assw"
+
+    # Australia
+    ["australiaeast"]="auea"
+    ["australiasoutheast"]="ause"
+
+    # Brazil
+    ["brazilsouth"]="brso"
+
+    # Canada
+    ["canadacentral"]="cace"
+    ["canadaeast"]="caea"
+    ["uksouth"]="ukso"
+    ["ukwest"]="ukwe"
+    ["koreacentral"]="koce"
+    ["koreasouth"]="koso"
+    ["francecentral"]="frce"
+    ["francesouth"]="frso"
+    ["australiacentral"]="auce"
+    ["australiacentral2"]="auc2"
+    ["southafricanorth"]="sano"
+    ["southafricawest"]="sawe"
+
+    # Europe
+    ["northeurope"]="euno"
+    ["westeurope"]="euwe"
+
+    # India
+    ["southindia"]="inso"
+    ["centralindia"]="ince"
+    ["westindia"]="inwe"
+
+    # Japan
+    ["japanwest"]="jawe"
+    ["japaneast"]="jaea"
+
+    # US
+    ["centralus"]="usce"
+    ["eastus"]="usea"
+    ["eastus2"]="use2"
+    ["westus"]="uswe"
+    ["westus2"]="usw2"
+    ["northcentralus"]="usnc"
+    ["southcentralus"]="ussc"
+    ["westcentralus"]="uswc"
+)
+
+locationCode=${locationCodes[$location]}
+
+[[ -z ${locationCode} ]] && {
+    echo "Invalid value '${location}' for location parameter.";
+    exit 1;
+}
+
+# Authenticate user.
+az login
+
+# Create the resource group.
+rgName="acr-${locationCode}-${company}"
+az group create --name $rgName --location $location
+
+# Create the container registry.
+acrName=${rgName//-/}
+acrId=$(az acr create --resource-group $rgName --name $acrName --sku Standard --query id)
+acrId="${acrId//\"}"
+# ToDo: Should parameterize 'sku' in the future 
+
+# Create service principals and role assignments to ACR.
+declare -A spAcrNameAndRole=(
+    ["http://acr-${company}-pull"]="AcrPull"
+    ["http://acr-${company}-push"]="AcrPush"
+)
+
+for spName in ${!spAcrNameAndRole[@]}
+do
+    echo "Creating service principal '${spName}'."
+    az ad sp create-for-rbac --name $spName --skip-assignment 
+    
+    echo "Waiting for service principal '${spName}' to propagate in Azure AD."
+    sleep 15s
+
+    echo "Creating role assignment for service principal '${spName}'."
+    az role assignment create --assignee $spName --scope $acrId --role AcrPull
+done

--- a/setup/acr-sp-init.sh
+++ b/setup/acr-sp-init.sh
@@ -117,8 +117,8 @@ do
     az ad sp create-for-rbac --name $spName --skip-assignment 
     
     echo "Waiting for service principal '${spName}' to propagate in Azure AD."
-    sleep 15s
+    sleep 20s
 
     echo "Creating role assignment for service principal '${spName}'."
-    az role assignment create --assignee $spName --scope $acrId --role AcrPull
+    az role assignment create --assignee $spName --scope $acrId --role ${spAcrNameAndRole[$spName]}
 done

--- a/setup/acr-sp-init.sh
+++ b/setup/acr-sp-init.sh
@@ -129,10 +129,10 @@ do
 
     # Get the role assignment scoped to the ACR for the service principal if it already exists.
     roleAssignment=""
-    roleAssignment=$(az role assignment list --assignee ${spName} --scope ${acrId} --role ${spAcrNameAndRole[$spName]})
+    roleAssignment=$(az role assignment list --assignee ${spName} --scope ${acrId} --role ${spAcrNameAndRole[$spName]} --query 'length(@)')
 
     # Create a new role assignment if it doesn't already exist.
-    [[ -z ${roleAssignment} ]] && {
+    [[ $roleAssignment -eq 0 ]] && {
         echo "Creating role assignment for service principal '${spName}'."
         az role assignment create --assignee $spName --scope $acrId --role ${spAcrNameAndRole[$spName]}
     }


### PR DESCRIPTION
## Steps to test

Change into the `./setup` folder.

Run the script `./acr-sp-init.sh` with necessary parameter values.  For example:

`./acr-sp-init.sh -c contoso -l eastus`

After the script completes successfully, test the results using the following commands:

```
// Test the resource group 
az group show --name acr-usea-contoso --query '[name,location]'

// Test the ACR resource
az acr show --name acruseacontoso --query '[name,location]'

// Test the service principals
az ad sp show --id http://acr-contoso-pull --query '[objectType,displayName]'
az ad sp show --id http://acr-contoso-push --query '[objectType,displayName]'

// Test the service principal role assignments
az role assignment list --assignee http://acr-contoso-pull --all --query '[].[principalName,roleDefinitionName]'
az role assignment list --assignee http://acr-contoso-push --all --query '[].[principalName,roleDefinitionName]'

```
#31 

