### PR TITLE
#37 Change acr-sp-init.sh to adhere to naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,25 @@ After saving the file set environment using:
 
 Alternative use the variable.tf files in the directories and add the default key on the file as shown on the example below:
 
-``` json
+```
 variable "location" {
-    type = "string",
-    description = "The name of the target location",
+    type = "string"
+    description = "The name of the target location"
     default = "eastus"
 }
 variable "env" {
-    type = "string",
-    description = "The short name of the target env (i.e. dev, staging, or prod)",
+    type = "string"
+    description = "The short name of the target env (i.e. dev, staging, or prod)"
     defailt = "dev"
 }
 variable "org" {
-    type = "string",
-    description = "The short name of the organization",
+    type = "string"
+    description = "The short name of the organization"
     default = "cse"
 }
 variable "app_name" {
-    type = "string",
-    description = "The short name of the application",
+    type = "string"
+    description = "The short name of the application"
     default = "cblt"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ The artifacts used to deploy this project include bash scripts and Terraform tem
 
     > Note: The script configures service principals in Azure AD and therefore requires elevated privileges.  As such, it is recommended that an interactive user with permissions to configure Azure AD run the script.
     
-    
+### Automated Test
+
+The automated test for this setup step is in `./tests/acr-sp-init-test.sh`.  It can be executed at the command line as shown below, or as part of a CI pipeline.
+
+``` bash
+az login
+./tests/acr-sp-init-sh
+```
+
 ## Setup Shared / Core Infrastructure
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<<<<<<< HEAD
-
 # Setup
 
 The artifacts used to deploy this project include bash scripts and Terraform templates.  The sections below provide guidance to deploy this project into your Azure environment.
@@ -14,10 +12,14 @@ The artifacts used to deploy this project include bash scripts and Terraform tem
 
 1. Open a bash command prompt.
 2. Navigate to the `./setup` folder.
-3. Run `acr-sp-init.sh`.  For example, the command below will provdision an Azure Container Registry (ACR) in East US and configure the two service principals in Azure Active Directory; one with AcrPush permission and another with AcrPull permission scoped to the ACR.  The company name parameter ( `-c` ) is used to construct the name of the resource group, ACR, and service principals.
+3. Authenticate to Azure.
+    ``` bash
+    az login
+    ```
+4. Run `acr-sp-init.sh`.  For example, the command below will provdision an Azure Container Registry (ACR) in East US and configure the two service principals in Azure Active Directory; one with AcrPush permission and another with AcrPull permission scoped to the ACR.  The script parameter values are used to construct the name of the resource group, ACR, and service principals.
 
     ``` bash
-    $ ./acr-sp-init.sh -c Cobalt -l eastus
+    $ ./acr-sp-init.sh -a Cblt -l eastus -s CoreProd
     ```
 
     > Note: The script configures service principals in Azure AD and therefore requires elevated privileges.  As such, it is recommended that an interactive user with permissions to configure Azure AD run the script.
@@ -72,26 +74,25 @@ Alternative use the variable.tf files in the directories and add the default key
 
 ``` json
 variable "location" {
-    type = "string"
-    description = "The name of the target location"
+    type = "string",
+    description = "The name of the target location",
     default = "eastus"
 }
 variable "env" {
     type = "string",
-    description = "The short name of the target env (i.e. dev, staging, or prod)"
+    description = "The short name of the target env (i.e. dev, staging, or prod)",
     defailt = "dev"
 }
 variable "org" {
     type = "string",
-    description = "The short name of the organization"
+    description = "The short name of the organization",
     default = "cse"
 }
 variable "app_name" {
     type = "string",
-    description = "The short name of the application"
+    description = "The short name of the application",
     default = "cblt"
 }
-
 ```
 
 ## Setup Application Infrastructure
@@ -112,51 +113,3 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-=======
-
-# Setup
-
-The artifacts used to deploy this project include bash scripts and Terraform templates.  The sections below provide guidance to deploy this project into your Azure environment.
-
-> The setup instructions below assume the following requirements:
-> - bash v4.0 (or newer)
->   - **NOTE FOR MAC!** The default version of bash installed on Mac is older than 4.0. Be sure to update bash using brew before executing the script. Instructions to update bash can be found [here](http://macappstore.org/bash/).
-> - Terraform v0.11.13 (or newer)
-
-
-## Setup the Azure Container Registry and Service Principals
-
-1. Open a bash command prompt.
-2. Navigate to the `./setup` folder.
-3. Run `acr-sp-init.sh`.  For example, the command below will provdision an Azure Container Registry (ACR) in East US and configure the two service principals in Azure Active Directory; one with AcrPush permission and another with AcrPull permission scoped to the ACR.  The company name parameter ( `-c` ) is used to construct the name of the resource group, ACR, and service principals.
-
-    ``` bash
-    $ ./acr-sp-init.sh -c Cobalt -l eastus
-    ```
-
-    > Note: The script configures service principals in Azure AD and therefore requires elevated privileges.  As such, it is recommended that an interactive user with permissions to configure Azure AD run the script.
-    
-    
-## Setup Shared / Core Infrastructure
-
-> Coming soon!
-
-## Setup Application Infrastructure
-
-> Coming soon!
-
-
-# Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
->>>>>>> master

--- a/setup/acr-setup-test.sh
+++ b/setup/acr-setup-test.sh
@@ -1,11 +1,76 @@
-#!/bin/bash +e
+#!/bin/bash -e
 
 # Test Input Values
 appName="CbltApp"
 location="eastus"
 suffix="Cntso Dev"
 
-bash ./acr-sp-init.sh -a $appName -l $location -s $suffix
+bash ./acr-sp-init.sh -a $appName -l $location -s "${suffix}"
+
+# Expected resource group properties
+rgName="cblt-usea-rg-cntsodev"
+rgLocation="eastus"
+expectedRgValues='['${rgName}','${rgLocation}']'
+
+# Expected ACR properties
+acrName="cbltuseaacrcntsodev"
+acrLocation="eastus"
+expectedAcrValues='['${acrName}','${acrLocation}']'
+
+# Expected service principal properties
+declare -A spAcrNameAndRole=(
+    ["http://cblt-usea-sp-cntsodev-pull"]="AcrPull"
+    ["http://cblt-usea-sp-cntsodev-push"]="AcrPush"
+)
 
 # Assertions
-# ToDo...
+# Test resource group
+echo "Testing resource group..."
+resourceValues=$(az group show --name $rgName --query '[name,location]' --output JSON)
+resourceValues=${resourceValues//[[:space:]]/}
+resourceValues=${resourceValues//\"/}
+
+[[ "$resourceValues" != "$expectedRgValues" ]] && {
+    echo "Error: Unexpected resource group values."
+    echo "  Results returned '${resourceValues}'"
+    echo "          expected '${expectedRgValues}'"
+    exit 1;
+}
+
+# Test ACR
+echo "Testing container registry..."
+resourceValues=$(az acr show --name $acrName --query '[name,location]' --output JSON)
+resourceValues=${resourceValues//[[:space:]]/}
+resourceValues=${resourceValues//\"/}
+
+[[ "$resourceValues" != "$expectedAcrValues" ]] && {
+    echo "Error: Unexpected container registry values."
+    echo "  Results returned '${resourceValues}'"
+    echo "          expected '${expectedAcrValues}'"
+    exit 1;
+}
+
+# Test service principals
+echo "Testing service principals..."
+for spName in ${!spAcrNameAndRole[@]}
+do
+    # Get the appId of the expected service principal
+    spAppId=$(az ad sp show --id ${spName} --query appId)
+    spAppId="${spAppId//\"}"
+
+    # Get the ACR ID for the container registry the service principal role assignments should be scoped to.
+    acrId=$(az acr show --name $acrName --query id)
+    acrId="${acrId//\"}"
+
+    # Get the role assignment scoped to the ACR for the service principal.
+    roleAssignment=$(az role assignment list --assignee ${spName} --scope ${acrId} --role ${spAcrNameAndRole[$spName]} --query 'length(@)')
+    [[ roleAssignment -eq 0 ]] && {
+        echo "Error: Role assignmet to ACR '${acrName}' for service principal '$spName' is missing."
+        exit 1;
+    }
+done
+
+echo "Tests passed successfully"
+
+
+

--- a/setup/acr-setup-test.sh
+++ b/setup/acr-setup-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash +e
+
+# Test Input Values
+appName="CbltApp"
+location="eastus"
+suffix="Cntso Dev"
+
+bash ./acr-sp-init.sh -a $appName -l $location -s $suffix
+
+# Assertions
+# ToDo...

--- a/setup/acr-sp-init.sh
+++ b/setup/acr-sp-init.sh
@@ -112,8 +112,8 @@ acrId="${acrId//\"}"
 
 # Used to find/create service principals and role assignments to ACR.
 declare -A spAcrNameAndRole=(
-    ["http://${appname}-${location}-sp-${suffix}-pull"]="AcrPull"
-    ["http://${appname}-${location}-sp-${suffix}-push"]="AcrPush"
+    ["http://${appname}-${locationCode}-sp-${suffix}-pull"]="AcrPull"
+    ["http://${appname}-${locationCode}-sp-${suffix}-push"]="AcrPush"
 )
 
 for spName in ${!spAcrNameAndRole[@]}

--- a/tests/acr-sp-init-test.sh
+++ b/tests/acr-sp-init-test.sh
@@ -52,15 +52,16 @@ fi
 
 # Test service principals
 echo "Testing service principals..."
+
+# Get the ACR ID for the container registry the service principal role assignments should be scoped to.
+acrId=$(az acr show --name $acrName --query id)
+acrId="${acrId//\"}"
+
 for spName in ${!spAcrNameAndRole[@]}
 do
     # Get the appId of the expected service principal
     spAppId=$(az ad sp show --id ${spName} --query appId)
     spAppId="${spAppId//\"}"
-
-    # Get the ACR ID for the container registry the service principal role assignments should be scoped to.
-    acrId=$(az acr show --name $acrName --query id)
-    acrId="${acrId//\"}"
 
     # Get the role assignment scoped to the ACR for the service principal.
     roleAssignment=$(az role assignment list --assignee ${spName} --scope ${acrId} --role ${spAcrNameAndRole[$spName]} --query 'length(@)')
@@ -71,6 +72,27 @@ do
 done
 
 echo "Tests passed successfully"
+
+# Clean up tests results
+echo "Cleaning up test resources"
+
+echo "  Cleaning up service principals and role assignments..."
+for spName in ${!spAcrNameAndRole[@]}
+do
+    # Clean up service principals and role assignments
+    spAppId=$(az ad sp show --id ${spName} --query appId)
+    spAppId="${spAppId//\"}"
+    az ad sp delete --id ${spAppId}
+done
+
+# Clean up container registry
+echo "  Cleaning up container registry..."
+az acr delete --name ${acrName}
+
+# Clean up resource group
+echo "  Cleaning up resource group..."
+az group delete --name ${rgName} --yes
+
 
 
 

--- a/tests/acr-sp-init-test.sh
+++ b/tests/acr-sp-init-test.sh
@@ -30,12 +30,12 @@ resourceValues=$(az group show --name $rgName --query '[name,location]' --output
 resourceValues=${resourceValues//[[:space:]]/}
 resourceValues=${resourceValues//\"/}
 
-[[ "$resourceValues" != "$expectedRgValues" ]] && {
+if [[ "$resourceValues" != "$expectedRgValues" ]]; then
     echo "Error: Unexpected resource group values."
     echo "  Results returned '${resourceValues}'"
     echo "          expected '${expectedRgValues}'"
     exit 1;
-}
+fi
 
 # Test ACR
 echo "Testing container registry..."
@@ -43,12 +43,12 @@ resourceValues=$(az acr show --name $acrName --query '[name,location]' --output 
 resourceValues=${resourceValues//[[:space:]]/}
 resourceValues=${resourceValues//\"/}
 
-[[ "$resourceValues" != "$expectedAcrValues" ]] && {
+if [[ "$resourceValues" != "$expectedAcrValues" ]]; then
     echo "Error: Unexpected container registry values."
     echo "  Results returned '${resourceValues}'"
     echo "          expected '${expectedAcrValues}'"
     exit 1;
-}
+fi
 
 # Test service principals
 echo "Testing service principals..."
@@ -64,10 +64,10 @@ do
 
     # Get the role assignment scoped to the ACR for the service principal.
     roleAssignment=$(az role assignment list --assignee ${spName} --scope ${acrId} --role ${spAcrNameAndRole[$spName]} --query 'length(@)')
-    [[ roleAssignment -eq 0 ]] && {
+    if [[ roleAssignment -eq 0 ]]; then
         echo "Error: Role assignmet to ACR '${acrName}' for service principal '$spName' is missing."
         exit 1;
-    }
+    fi
 done
 
 echo "Tests passed successfully"

--- a/tests/acr-sp-init-test.sh
+++ b/tests/acr-sp-init-test.sh
@@ -5,7 +5,7 @@ appName="CbltApp"
 location="eastus"
 suffix="Cntso Dev"
 
-bash ./acr-sp-init.sh -a $appName -l $location -s "${suffix}"
+bash ../setup/acr-sp-init.sh -a $appName -l $location -s "${suffix}"
 
 # Expected resource group properties
 rgName="cblt-usea-rg-cntsodev"


### PR DESCRIPTION
This PR includes a new script, `./setup/acr-setup-test.sh` to automate testing the functionality of `./setup/acr-setup.sh`.  To test the new functionality, run the following commands from a bash prompt:

``` bash
# Authenticate to Azure
az login   

cd ./tests
./acr-sp-init-test.sh
```
